### PR TITLE
Add underscore to 'I' letter methods to avoid conflict with macro in …

### DIFF
--- a/UAObfuscatedString.h
+++ b/UAObfuscatedString.h
@@ -50,7 +50,7 @@
 - (instancetype)F;
 - (instancetype)G;
 - (instancetype)H;
-- (instancetype)I;
+- (instancetype)_I;
 - (instancetype)J;
 - (instancetype)K;
 - (instancetype)L;

--- a/UAObfuscatedString.m
+++ b/UAObfuscatedString.m
@@ -46,7 +46,7 @@
 - (instancetype)F { [self appendString:@"F"]; return self; }
 - (instancetype)G { [self appendString:@"G"]; return self; }
 - (instancetype)H { [self appendString:@"H"]; return self; }
-- (instancetype)I { [self appendString:@"I"]; return self; }
+- (instancetype)_I { [self appendString:@"I"]; return self; }
 - (instancetype)J { [self appendString:@"J"]; return self; }
 - (instancetype)K { [self appendString:@"K"]; return self; }
 - (instancetype)L { [self appendString:@"L"]; return self; }

--- a/UAObfuscatedString.podspec
+++ b/UAObfuscatedString.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "UAObfuscatedString"
-  s.version      = "0.3.1"
+  s.version      = "0.3.2"
   s.summary      = "A simple NSMutableString subclass to hide sensitive strings from appearing in your binary"
   s.description  = <<-DESC
                    UAObfuscatedString is a simple and lightweight subclass of NSMutableString that allows you to prevent sensitive strings from appearing in the binary. Without some sort of obfuscation, strings like backend API methods and urls, API keys and other sensitive data can be read by utilizing various tools such as strings.


### PR DESCRIPTION
Add underscore to 'I' letter methods to avoid conflict with macro in 10.11 SDK; increased minor version