### PR TITLE
Separate categories for `NSMutableString`

### DIFF
--- a/UAObfuscatedString.swift
+++ b/UAObfuscatedString.swift
@@ -6,7 +6,7 @@
 //
 
 // MARK: - a-z -
-@objc public extension String {
+public extension String {
     var a : String { get { return self + "a" } }
     var b : String { get { return self + "b" } }
     var c : String { get { return self + "c" } }
@@ -35,8 +35,37 @@
     var z : String { get { return self + "z" } }
 }
 
+public extension NSMutableString {
+    var a : NSMutableString { get { append("a"); return self } }
+    var b : NSMutableString { get { append("b"); return self } }
+    var c : NSMutableString { get { append("c"); return self } }
+    var d : NSMutableString { get { append("d"); return self } }
+    var e : NSMutableString { get { append("e"); return self } }
+    var f : NSMutableString { get { append("f"); return self } }
+    var g : NSMutableString { get { append("g"); return self } }
+    var h : NSMutableString { get { append("h"); return self } }
+    var i : NSMutableString { get { append("i"); return self } }
+    var j : NSMutableString { get { append("j"); return self } }
+    var k : NSMutableString { get { append("k"); return self } }
+    var l : NSMutableString { get { append("l"); return self } }
+    var m : NSMutableString { get { append("m"); return self } }
+    var n : NSMutableString { get { append("n"); return self } }
+    var o : NSMutableString { get { append("o"); return self } }
+    var p : NSMutableString { get { append("p"); return self } }
+    var q : NSMutableString { get { append("q"); return self } }
+    var r : NSMutableString { get { append("r"); return self } }
+    var s : NSMutableString { get { append("s"); return self } }
+    var t : NSMutableString { get { append("t"); return self } }
+    var u : NSMutableString { get { append("u"); return self } }
+    var v : NSMutableString { get { append("v"); return self } }
+    var w : NSMutableString { get { append("w"); return self } }
+    var x : NSMutableString { get { append("x"); return self } }
+    var y : NSMutableString { get { append("y"); return self } }
+    var z : NSMutableString { get { append("z"); return self } }
+}
+
 // MARK: - A-Z -
-@objc public extension String {
+public extension String {
     var A : String { get { return self + "A" } }
     var B : String { get { return self + "B" } }
     var C : String { get { return self + "C" } }
@@ -65,8 +94,37 @@
     var Z : String { get { return self + "Z" } }
 }
 
+public extension NSMutableString {
+    var A : NSMutableString { get { append("A"); return self } }
+    var B : NSMutableString { get { append("B"); return self } }
+    var C : NSMutableString { get { append("C"); return self } }
+    var D : NSMutableString { get { append("D"); return self } }
+    var E : NSMutableString { get { append("E"); return self } }
+    var F : NSMutableString { get { append("F"); return self } }
+    var G : NSMutableString { get { append("G"); return self } }
+    var H : NSMutableString { get { append("H"); return self } }
+    var I : NSMutableString { get { append("I"); return self } }
+    var J : NSMutableString { get { append("J"); return self } }
+    var K : NSMutableString { get { append("K"); return self } }
+    var L : NSMutableString { get { append("L"); return self } }
+    var M : NSMutableString { get { append("M"); return self } }
+    var N : NSMutableString { get { append("N"); return self } }
+    var O : NSMutableString { get { append("O"); return self } }
+    var P : NSMutableString { get { append("P"); return self } }
+    var Q : NSMutableString { get { append("Q"); return self } }
+    var R : NSMutableString { get { append("R"); return self } }
+    var S : NSMutableString { get { append("S"); return self } }
+    var T : NSMutableString { get { append("T"); return self } }
+    var U : NSMutableString { get { append("U"); return self } }
+    var V : NSMutableString { get { append("V"); return self } }
+    var W : NSMutableString { get { append("W"); return self } }
+    var X : NSMutableString { get { append("X"); return self } }
+    var Y : NSMutableString { get { append("Y"); return self } }
+    var Z : NSMutableString { get { append("Z"); return self } }
+}
+
 // MARK: - Numbers -
-@objc public extension String {
+public extension String {
     var _1 : String { get { return self + "1" } }
     var _2 : String { get { return self + "2" } }
     var _3 : String { get { return self + "3" } }
@@ -77,11 +135,23 @@
     var _8 : String { get { return self + "8" } }
     var _9 : String { get { return self + "9" } }
     var _0 : String { get { return self + "0" } }
-    
+}
+
+public extension NSMutableString {
+    var _1 : NSMutableString { get { append("1"); return self } }
+    var _2 : NSMutableString { get { append("2"); return self } }
+    var _3 : NSMutableString { get { append("3"); return self } }
+    var _4 : NSMutableString { get { append("4"); return self } }
+    var _5 : NSMutableString { get { append("5"); return self } }
+    var _6 : NSMutableString { get { append("6"); return self } }
+    var _7 : NSMutableString { get { append("7"); return self } }
+    var _8 : NSMutableString { get { append("8"); return self } }
+    var _9 : NSMutableString { get { append("9"); return self } }
+    var _0 : NSMutableString { get { append("0"); return self } }
 }
 
 // MARK: - Punctuation -
-@objc public extension String {
+public extension String {
     var space         : String { get { return self + " " } }
     var point         : String { get { return self + "." } }
     var dash          : String { get { return self + "-" } }
@@ -115,8 +185,45 @@
     var underscore    : String { get { return self + "_" } }
 }
 
+public extension NSMutableString {
+    var space         : NSMutableString { get { append(" "); return self } }
+    var point         : NSMutableString { get { append("."); return self } }
+    var dash          : NSMutableString { get { append("-"); return self } }
+    var comma         : NSMutableString { get { append(","); return self } }
+    var semicolon     : NSMutableString { get { append(";"); return self } }
+    var colon         : NSMutableString { get { append(":"); return self } }
+    var apostrophe    : NSMutableString { get { append("'"); return self } }
+    var quotation     : NSMutableString { get { append("\""); return self } }
+    var plus          : NSMutableString { get { append("+"); return self } }
+    var equals        : NSMutableString { get { append("="); return self } }
+    var paren_left    : NSMutableString { get { append("("); return self } }
+    var paren_right   : NSMutableString { get { append(")"); return self } }
+    var asterisk      : NSMutableString { get { append("*"); return self } }
+    var ampersand     : NSMutableString { get { append("&"); return self } }
+    var caret         : NSMutableString { get { append("^"); return self } }
+    var percent       : NSMutableString { get { append("%"); return self } }
+    var `$`           : NSMutableString { get { append("$"); return self } }
+    var pound         : NSMutableString { get { append("#"); return self } }
+    var at            : NSMutableString { get { append("@"); return self } }
+    var exclamation   : NSMutableString { get { append("!"); return self } }
+    var question_mark : NSMutableString { get { append("?"); return self } }
+    var back_slash    : NSMutableString { get { append("\\"); return self } }
+    var forward_slash : NSMutableString { get { append("/"); return self } }
+    var curly_left    : NSMutableString { get { append("{"); return self } }
+    var curly_right   : NSMutableString { get { append("}"); return self } }
+    var bracket_left  : NSMutableString { get { append("["); return self } }
+    var bracket_right : NSMutableString { get { append("]"); return self } }
+    var bar           : NSMutableString { get { append("|"); return self } }
+    var less_than     : NSMutableString { get { append("<"); return self } }
+    var greater_than  : NSMutableString { get { append(">"); return self } }
+    var underscore    : NSMutableString { get { append("_"); return self } }
+}
+
 // MARK: - Aliases -
-@objc public extension String {
+public extension String {
     var dot         : String { get { return point } }
 }
 
+public extension NSMutableString {
+    var dot         : NSMutableString { get { append(point); return self } }
+}

--- a/UAObfuscatedString.swift
+++ b/UAObfuscatedString.swift
@@ -6,7 +6,7 @@
 //
 
 // MARK: - a-z -
-public extension String {
+@objc public extension String {
     var a : String { get { return self + "a" } }
     var b : String { get { return self + "b" } }
     var c : String { get { return self + "c" } }
@@ -36,7 +36,7 @@ public extension String {
 }
 
 // MARK: - A-Z -
-public extension String {
+@objc public extension String {
     var A : String { get { return self + "A" } }
     var B : String { get { return self + "B" } }
     var C : String { get { return self + "C" } }
@@ -66,7 +66,7 @@ public extension String {
 }
 
 // MARK: - Numbers -
-public extension String {
+@objc public extension String {
     var _1 : String { get { return self + "1" } }
     var _2 : String { get { return self + "2" } }
     var _3 : String { get { return self + "3" } }
@@ -81,7 +81,7 @@ public extension String {
 }
 
 // MARK: - Punctuation -
-public extension String {
+@objc public extension String {
     var space         : String { get { return self + " " } }
     var point         : String { get { return self + "." } }
     var dash          : String { get { return self + "-" } }
@@ -98,7 +98,7 @@ public extension String {
     var ampersand     : String { get { return self + "&" } }
     var caret         : String { get { return self + "^" } }
     var percent       : String { get { return self + "%" } }
-    var $             : String { get { return self + "$" } }
+    var `$`           : String { get { return self + "$" } }
     var pound         : String { get { return self + "#" } }
     var at            : String { get { return self + "@" } }
     var exclamation   : String { get { return self + "!" } }
@@ -116,7 +116,7 @@ public extension String {
 }
 
 // MARK: - Aliases -
-public extension String {
+@objc public extension String {
     var dot         : String { get { return point } }
 }
 

--- a/UAObfuscatedString.swift
+++ b/UAObfuscatedString.swift
@@ -35,7 +35,7 @@ public extension String {
     var z : String { get { return self + "z" } }
 }
 
-public extension NSMutableString {
+@objc public extension NSMutableString {
     var a : NSMutableString { get { append("a"); return self } }
     var b : NSMutableString { get { append("b"); return self } }
     var c : NSMutableString { get { append("c"); return self } }
@@ -94,7 +94,7 @@ public extension String {
     var Z : String { get { return self + "Z" } }
 }
 
-public extension NSMutableString {
+@objc public extension NSMutableString {
     var A : NSMutableString { get { append("A"); return self } }
     var B : NSMutableString { get { append("B"); return self } }
     var C : NSMutableString { get { append("C"); return self } }
@@ -137,7 +137,7 @@ public extension String {
     var _0 : String { get { return self + "0" } }
 }
 
-public extension NSMutableString {
+@objc public extension NSMutableString {
     var _1 : NSMutableString { get { append("1"); return self } }
     var _2 : NSMutableString { get { append("2"); return self } }
     var _3 : NSMutableString { get { append("3"); return self } }
@@ -185,7 +185,7 @@ public extension String {
     var underscore    : String { get { return self + "_" } }
 }
 
-public extension NSMutableString {
+@objc public extension NSMutableString {
     var space         : NSMutableString { get { append(" "); return self } }
     var point         : NSMutableString { get { append("."); return self } }
     var dash          : NSMutableString { get { append("-"); return self } }
@@ -224,6 +224,6 @@ public extension String {
     var dot         : String { get { return point } }
 }
 
-public extension NSMutableString {
+@objc public extension NSMutableString {
     var dot         : NSMutableString { get { return point } }
 }

--- a/UAObfuscatedString.swift
+++ b/UAObfuscatedString.swift
@@ -225,5 +225,5 @@ public extension String {
 }
 
 public extension NSMutableString {
-    var dot         : NSMutableString { get { append(point); return self } }
+    var dot         : NSMutableString { get { return point } }
 }


### PR DESCRIPTION
Created separate categories for `NSMutableString` so library is accessible from both Swift and Objective-C without any types bridging.